### PR TITLE
fix issue with font leakage

### DIFF
--- a/!throwback/c/main
+++ b/!throwback/c/main
@@ -229,6 +229,8 @@ void gui_closeDown(void)
    regs.r[0] = gui_handle;
 
    wimpt_complain(os_swix(DDEUtils_ThrowbackUnRegister, &regs));
+
+   textPane_destroy(textPane);
 }
 
 static void info_about(void)

--- a/!throwback/c/textpane
+++ b/!throwback/c/textpane
@@ -312,6 +312,8 @@ void textPane_destroy(TextPane *tp)
      
    free(tp->line);
    free(tp);
+
+   font_lose(tp->font);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
textPane_destroy now calls font_lose to release the resources assoicated with the textPane font, gui_closeDown in main.c now calls textPane_destroy